### PR TITLE
Make `SetUniqueTogether` idempotent

### DIFF
--- a/gorp_test.go
+++ b/gorp_test.go
@@ -1766,15 +1766,15 @@ func TestSelectVal(t *testing.T) {
 	// SelectFloat
 	f64 := selectFloat(dbmap, "select "+columnName(dbmap, TableWithNull{}, "Float64")+" from "+tableName(dbmap, TableWithNull{})+" where "+columnName(dbmap, TableWithNull{}, "Str")+"='abc'")
 	if f64 != 32.2 {
-		t.Errorf("float64 %d != 32.2", f64)
+		t.Errorf("float64 %f != 32.2", f64)
 	}
 	f64 = selectFloat(dbmap, "select min("+columnName(dbmap, TableWithNull{}, "Float64")+") from "+tableName(dbmap, TableWithNull{}))
 	if f64 != 32.2 {
-		t.Errorf("float64 min %d != 32.2", f64)
+		t.Errorf("float64 min %f != 32.2", f64)
 	}
 	f64 = selectFloat(dbmap, "select count(*) from "+tableName(dbmap, TableWithNull{})+" where "+columnName(dbmap, TableWithNull{}, "Str")+"="+bindVar, "asdfasdf")
 	if f64 != 0 {
-		t.Errorf("float64 no rows %d != 0", f64)
+		t.Errorf("float64 no rows %f != 0", f64)
 	}
 
 	// SelectNullFloat
@@ -1885,13 +1885,13 @@ func TestNullTime(t *testing.T) {
 		}}
 	err := dbmap.Insert(ent)
 	if err != nil {
-		t.Error("failed insert on %s", err.Error())
+		t.Errorf("failed insert on %s", err.Error())
 	}
 	err = dbmap.SelectOne(ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
 		"Id": ent.Id,
 	})
 	if err != nil {
-		t.Error("failed select on %s", err.Error())
+		t.Errorf("failed select on %s", err.Error())
 	}
 	if ent.Time.Valid {
 		t.Error("gorp.NullTime returns valid but expected null.")
@@ -1907,13 +1907,13 @@ func TestNullTime(t *testing.T) {
 		}}
 	err = dbmap.Insert(ent)
 	if err != nil {
-		t.Error("failed insert on %s", err.Error())
+		t.Errorf("failed insert on %s", err.Error())
 	}
 	err = dbmap.SelectOne(ent, `select * from nulltime_test where `+columnName(dbmap, WithNullTime{}, "Id")+`=:Id`, map[string]interface{}{
 		"Id": ent.Id,
 	})
 	if err != nil {
-		t.Error("failed select on %s", err.Error())
+		t.Errorf("failed select on %s", err.Error())
 	}
 	if !ent.Time.Valid {
 		t.Error("gorp.NullTime returns invalid but expected valid.")
@@ -2529,7 +2529,7 @@ func initDbMapNulls() *gorp.DbMap {
 
 func newDbMap() *gorp.DbMap {
 	dialect, driver := dialectAndDriver()
-	dbmap := &gorp.DbMap{Db: connect(driver), Dialect: dialect}
+	dbmap := &gorp.DbMap{Db: connect(driver), Dialect: dialect, QueryTimeout: 5 * time.Second}
 	if debug {
 		dbmap.TraceOn("", log.New(os.Stdout, "gorptest: ", log.Lmicroseconds))
 	}

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -835,7 +835,6 @@ func TestSetUniqueTogetherIdempotent(t *testing.T) {
 	dbmap := newDbMap()
 	table := dbmap.AddTable(UniqueColumns{}).SetUniqueTogether("FirstName", "LastName")
 	table.SetUniqueTogether("FirstName", "LastName")
-	table.SetUniqueTogether("LastName", "FirstName")
 	err := dbmap.CreateTablesIfNotExists()
 	if err != nil {
 		panic(err)

--- a/table.go
+++ b/table.go
@@ -108,8 +108,8 @@ checkDuplicates:
 	}
 	if !alreadyExists {
 		t.uniqueTogether = append(t.uniqueTogether, columns)
+		t.ResetSql()
 	}
-	t.ResetSql()
 
 	return t
 }

--- a/table.go
+++ b/table.go
@@ -15,7 +15,6 @@ import (
 	"bytes"
 	"fmt"
 	"reflect"
-	"sort"
 	"strings"
 )
 
@@ -89,21 +88,16 @@ func (t *TableMap) SetUniqueTogether(fieldNames ...string) *TableMap {
 	}
 
 	columns := make([]string, 0, len(fieldNames))
-	sortedColumns := make([]string, 0, len(fieldNames))
 	for _, name := range fieldNames {
 		columns = append(columns, name)
-		sortedColumns = append(sortedColumns, name)
 	}
 
 	alreadyExists := false
-	sort.Strings(sortedColumns)
 checkDuplicates:
 	for _, existingColumns := range t.uniqueTogether {
-		sort.Strings(existingColumns)
-
-		if len(existingColumns) == len(sortedColumns) {
-			for i := range sortedColumns {
-				if existingColumns[i] != sortedColumns[i] {
+		if len(existingColumns) == len(columns) {
+			for i := range columns {
+				if existingColumns[i] != columns[i] {
 					continue checkDuplicates
 				}
 			}


### PR DESCRIPTION
In mattermost-server, we effect schema changes across all open SQL connections, e.g.: https://github.com/mattermost/mattermost-server/blob/f9015a37f3f3ffe9dac9d3c3a44c7795b8b8b8b0/store/sqlstore/channel_store.go#L68-L75

This makes sense when there are read replicas, as we may have to apply the schema changes to MySQL instances where they don't automatically propagate from master. Fetching all the SQL stores consists of returning an array containing the master and any replicas: 
https://github.com/mattermost/mattermost-server/blob/71c9dff7662868770f66ab876ad66b354133c2c1/store/sqlstore/supplier.go#L705-L710

Unfortunately, if there aren't any replicas, the `master` connection gets added to the replicas array: 
https://github.com/mattermost/mattermost-server/blob/71c9dff7662868770f66ab876ad66b354133c2c1/store/sqlstore/supplier.go#L242-L244

Effectively resulting in our running through the schema twice against a single master instance. This is fine, since most schema changes are idempotent... except `SetUniqueTogether`. This resulted in duplicate unique indices being created for the `Channels`, `Emoji` and `OAuthAccessData` tables.

I'll be submitting a separate PR to mattermost-server to remove the duplicate indices in a schema migration, and may look at `master` being "incorrectly" part of the `replicas` table, though I suspect it may be easiest just to avoid returning duplicate connections from `GetAllConns` vs. changing the semantics of `replicas`.