### PR TITLE
unified string size constraint between mysql & postgres

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -72,8 +72,8 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 		return "datetime"
 	}
 
-	if maxsize < 1 {
-		maxsize = 255
+	if maxsize < 1 || maxsize > 16384 {
+		maxsize = 16384
 	}
 
 	/* == About varchar(N) ==
@@ -86,11 +86,9 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 	 * So it would be better to use 'text' type in stead of
 	 * large varchar type.
 	 */
-	if maxsize < 256 {
-		return fmt.Sprintf("varchar(%d)", maxsize)
-	} else {
-		return "text"
-	}
+
+	return fmt.Sprintf("varchar(%d)", maxsize)
+
 }
 
 // Returns auto_increment

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -61,9 +61,9 @@ var _ = Describe("MySQLDialect", func() {
 		Entry("NullFloat64", sql.NullFloat64{}, 0, false, "double"),
 		Entry("NullBool", sql.NullBool{}, 0, false, "tinyint"),
 		Entry("Time", time.Time{}, 0, false, "datetime"),
-		Entry("default-size string", "", 0, false, "varchar(255)"),
+		Entry("default-size string", "", 0, false, "varchar(16384)"),
 		Entry("sized string", "", 50, false, "varchar(50)"),
-		Entry("large string", "", 1024, false, "text"),
+		Entry("large string", "", 32768, false, "varchar(16384)"),
 	)
 
 	Describe("AutoIncrStr", func() {

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -62,11 +62,19 @@ func (d PostgresDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr boo
 		return "timestamp with time zone"
 	}
 
-	if maxsize > 0 {
-		return fmt.Sprintf("varchar(%d)", maxsize)
-	} else {
-		return "text"
+	if maxsize < 1 || maxsize > 16384 {
+		maxsize = 16384
 	}
+
+	/* == About varchar(N) ==
+	 * We want a unified behavior between mysql and postgres.
+	 * That's why we're not using postgres 'text' type for maxsize=0.
+	 * Note that for postgres, varchar(x) is basically 'text'
+	 * with an added constraint. This implies a small performance
+	 * hit because of the constraint check.
+	 */
+
+	return fmt.Sprintf("varchar(%d)", maxsize)
 
 }
 


### PR DESCRIPTION
Issue 10328 from mattermost-server
https://github.com/mattermost/mattermost-server/issues/10328

Use varchar for every string size, never 'text'.
Remove the 255 cap on string size.