### PR TITLE
handle string size more consistently in mysql dialect

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -89,8 +89,7 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 	} else if maxsize < 256 {
 		return fmt.Sprintf("varchar(%d)", maxsize)
 	} else {
-		// mysql will choose the right text variant according to the specified size
-		return fmt.Sprintf("text(%d)", maxsize)
+		return "text"
 	}
 }
 

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -86,7 +86,7 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 	if maxsize == 0 {
 		// Closer match for unbounded text
 		return "longtext"
-	} else if maxsize < 513 {
+	} else if maxsize < 256 {
 		return fmt.Sprintf("varchar(%d)", maxsize)
 	} else {
 		// mysql will choose the right text variant according to the specified size

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -72,24 +72,25 @@ func (d MySQLDialect) ToSqlType(val reflect.Type, maxsize int, isAutoIncr bool) 
 		return "datetime"
 	}
 
-	if maxsize < 1 {
-		maxsize = 255
-	}
-
 	/* == About varchar(N) ==
 	 * N is number of characters.
-	 * A varchar column can store up to 65535 bytes.
-	 * Remember that 1 character is 3 bytes in utf-8 charset.
-	 * Also remember that each row can store up to 65535 bytes,
-	 * and you have some overheads, so it's not possible for a
-	 * varchar column to have 65535/3 characters really.
-	 * So it would be better to use 'text' type in stead of
-	 * large varchar type.
+	 * According to the documentation, 0 < N <= 65535.
+	 * But one utf-8 character takes 3 bytes and each row can
+	 * be only 65535 bytes. So there is no way to know exactly
+	 * how many chars a varchar column can actually store.
+	 * Text columns contribute only up to 12 bytes to the row
+	 * size as their contents are stored off-page.
+	 * Hence, we use a conservative maximum of 512 for varchar,
+	 * after which we switch to the text type.
 	 */
-	if maxsize < 256 {
+	if maxsize == 0 {
+		// Closer match for unbounded text
+		return "longtext"
+	} else if maxsize < 513 {
 		return fmt.Sprintf("varchar(%d)", maxsize)
 	} else {
-		return "text"
+		// mysql will choose the right text variant according to the specified size
+		return fmt.Sprintf("text(%d)", maxsize)
 	}
 }
 

--- a/dialect_mysql_test.go
+++ b/dialect_mysql_test.go
@@ -61,9 +61,9 @@ var _ = Describe("MySQLDialect", func() {
 		Entry("NullFloat64", sql.NullFloat64{}, 0, false, "double"),
 		Entry("NullBool", sql.NullBool{}, 0, false, "tinyint"),
 		Entry("Time", time.Time{}, 0, false, "datetime"),
-		Entry("default-size string", "", 0, false, "varchar(255)"),
+		Entry("default-size string", "", 0, false, "longtext"),
 		Entry("sized string", "", 50, false, "varchar(50)"),
-		Entry("large string", "", 1024, false, "text"),
+		Entry("large string", "", 1024, false, "text(1024)"),
 	)
 
 	Describe("AutoIncrStr", func() {


### PR DESCRIPTION
Use longtext for maxsize=0, varchar for maxsize <= 512 and text if maxsize > 512.
No change to the postgres dialect.

regarding issue https://github.com/mattermost/mattermost-server/issues/10328
alternative to https://github.com/mattermost/gorp/pull/4