### PR TITLE
MM-27508 Allow default constraints

### DIFF
--- a/column.go
+++ b/column.go
@@ -28,6 +28,10 @@ type ColumnMap struct {
 	// Not used elsewhere
 	Unique bool
 
+	// If not nil, " default 'value'" is added to the create table statements.
+	// Not used elsewhere
+	DefaultConstraint *string
+
 	// Query used for getting generated id after insert
 	GeneratedIdQuery string
 
@@ -79,5 +83,12 @@ func (c *ColumnMap) SetNotNull(nn bool) *ColumnMap {
 // to alter the generated type for "create table" statements
 func (c *ColumnMap) SetMaxSize(size int) *ColumnMap {
 	c.MaxSize = size
+	return c
+}
+
+// SetDefaultConstraint adds " default 'value'" to the create table statements for this
+// column, if value is not nil. Not used elsewhere
+func (c *ColumnMap) SetDefaultConstraint(value *string) *ColumnMap {
+	c.DefaultConstraint = value
 	return c
 }

--- a/gorp_test.go
+++ b/gorp_test.go
@@ -72,6 +72,12 @@ type Invoice struct {
 	IsPaid   bool
 }
 
+type InvoiceWithMemoDefault struct {
+	Id              int64
+	Memo            string
+	MemoWithDefault string
+}
+
 type InvoiceWithValuer struct {
 	Id      int64
 	Created int64
@@ -1325,6 +1331,10 @@ func TestColumnProps(t *testing.T) {
 	t1.ColMap("Memo").SetMaxSize(10)
 	t1.ColMap("PersonId").SetUnique(true)
 
+	t2 := dbmap.AddTable(InvoiceWithMemoDefault{}).SetKeys(true, "Id")
+	t2.ColMap("Memo").SetMaxSize(10)
+	t2.ColMap("MemoWithDefault").SetMaxSize(60).SetDefaultConstraint(NewString("default"))
+
 	err := dbmap.CreateTables()
 	if err != nil {
 		panic(err)
@@ -1352,6 +1362,16 @@ func TestColumnProps(t *testing.T) {
 	err = dbmap.Insert(inv)
 	if err == nil {
 		t.Errorf("same PersonId inserted, but Insert did not fail.")
+	}
+
+	// test default
+	rawExec(dbmap, "insert into "+tableName(dbmap, InvoiceWithMemoDefault{})+
+		" (Id, Memo) values (1, 'my memo');")
+
+	obj2 := _get(dbmap, InvoiceWithMemoDefault{}, 1)
+	inv2 := obj2.(*InvoiceWithMemoDefault)
+	if inv2.MemoWithDefault != "default" {
+		t.Errorf("db did not create a default value for 'MemoWithDefault'")
 	}
 }
 
@@ -2791,3 +2811,5 @@ func columnName(dbmap *gorp.DbMap, i interface{}, fieldName string) string {
 	}
 	return fieldName
 }
+
+func NewString(s string) *string { return &s }

--- a/table.go
+++ b/table.go
@@ -221,6 +221,9 @@ func (t *TableMap) SqlForCreate(ifNotExists bool) string {
 			if col.isPK || col.isNotNull {
 				s.WriteString(" not null")
 			}
+			if col.DefaultConstraint != nil {
+				s.WriteString(fmt.Sprintf(" default '%s'", *col.DefaultConstraint))
+			}
 			if col.isPK && len(t.keys) == 1 {
 				s.WriteString(" primary key")
 			}


### PR DESCRIPTION
#### Summary

- We need to allow default constraints during table creation or else gorp's database schema will differ from the one created by a migration if the migration uses `sqlStore.CreateColumnIfNotExists`, which takes a default.

#### Links
- https://mattermost.atlassian.net/browse/MM-27508