### PR TITLE
Allow setting custom column data type

### DIFF
--- a/column.go
+++ b/column.go
@@ -41,6 +41,9 @@ type ColumnMap struct {
 
 	DefaultValue string
 
+	// The column data type. If set it overrides the one converted from the Go type.
+	DataType string
+
 	fieldName  string
 	gotype     reflect.Type
 	isPK       bool
@@ -83,6 +86,12 @@ func (c *ColumnMap) SetNotNull(nn bool) *ColumnMap {
 // to alter the generated type for "create table" statements
 func (c *ColumnMap) SetMaxSize(size int) *ColumnMap {
 	c.MaxSize = size
+	return c
+}
+
+// SetDataType allows to specify a custom data type for the column.
+func (c *ColumnMap) SetDataType(dataType string) *ColumnMap {
+	c.DataType = dataType
 	return c
 }
 

--- a/table.go
+++ b/table.go
@@ -215,7 +215,12 @@ func (t *TableMap) SqlForCreate(ifNotExists bool) string {
 			if x > 0 {
 				s.WriteString(", ")
 			}
-			stype := dialect.ToSqlType(col.gotype, col.MaxSize, col.isAutoIncr)
+
+			stype := col.DataType
+			if stype == "" {
+				stype = dialect.ToSqlType(col.gotype, col.MaxSize, col.isAutoIncr)
+			}
+
 			s.WriteString(fmt.Sprintf("%s %s", dialect.QuoteField(col.ColumnName), stype))
 
 			if col.isPK || col.isNotNull {


### PR DESCRIPTION
#### Summary

This is a needed step to support JSON native types and unblock [MM-36995](https://mattermost.atlassian.net/browse/MM-36995).  I opted for a method instead of a tag to be more explicit and have more control from the application side instead of relying on gorp internally mapping types for the two dbs.


